### PR TITLE
let users input Ruby string instead of Ruby file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,16 @@ Simple class for parsing ruby files, getting their methods, arguments, comments 
 
 ```js
 const ruby = require('ruby_parser');
-const parser = new ruby('tests/test.rb');
+const parserObj = new ruby();
 
-const info = parser.getInfo();
-const methods = parser.getMethods();
-const comments = parser.getComments();
-const ast = parser.getAst();
+const parsed = parserObj.parse({
+    filePath: 'tests/test.rb',
+    // rubyString: `i = 7` // you can use filePath or rubyString
+});
+
+const info = parsed.getInfo();
+const methods = parsed.getMethods();
+const comments = parsed.getComments();
+const ast = parsed.getAst();
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,21 @@
 class rubyParser {
-    constructor(file) {
-        const parser = require('./nodejs-lib-ruby-parser');
-        const fs = require('fs');
-        this.file = file;
-        this.source = fs.readFileSync(this.file, 'utf8');
-        this.parsed = parser.parse(this.source);
+    parser;
+    parsed;
+    fs;
+    constructor() {
+        this.parser = require('./nodejs-lib-ruby-parser');
+        this.fs = require('fs');
+    }
+
+    parse({filePath, rubyString}) {
+        if (typeof rubyString === "string") {
+            this.parsed = this.parser.parse(rubyString);
+            return this.parsed.ast;
+        } else if (typeof filePath === "string") {
+            this.source = fs.readFileSync(filePath, 'utf8');
+            this.parsed = this.parser.parse(this.source);
+            return this.parsed.ast;
+        }
     }
     getInfo() {
         return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruby_parser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "JS Ruby file parser",
   "module": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi, please let users be able to input Ruby string instead of only Ruby file path. I am the author of "Blockman" VS Code extension, and I need a function which takes a Ruby string and returns parsed data, so Blockman could support Ruby language. Thank you.